### PR TITLE
Fix forced x64 triplet

### DIFF
--- a/automate-vcpkg.cmake
+++ b/automate-vcpkg.cmake
@@ -118,7 +118,7 @@ endmacro()
 macro(_install_or_update_vcpkg)
     if(NOT EXISTS ${VCPKG_ROOT})
         message(STATUS "Cloning vcpkg in ${VCPKG_ROOT}")
-        execute_process(COMMAND git clone https://github.com/Microsoft/vcpkg.git ${VCPKG_ROOT} --depth 1)
+        execute_process(COMMAND git clone https://github.com/Microsoft/vcpkg.git ${VCPKG_ROOT})
 
         # If a reproducible build is desired (and potentially old libraries are # ok), uncomment the
         # following line and pin the vcpkg repository to a specific githash.

--- a/automate-vcpkg.cmake
+++ b/automate-vcpkg.cmake
@@ -68,13 +68,15 @@ endif()
 if (WIN32)
 
     # Since the compiler checks haven't run yet, we need to figure
-    # out the value of CMAKE_SIZEOF_VOID_P ourselfs
+    # out the value of CMAKE_SIZEOF_VOID_P ourselfs.
+    # We also need to make sure the target platform isn't already set because
+    # ARM64 will be overriden by the 64bit check
 
     include(CheckTypeSize)
     enable_language(C)
     check_type_size("void*" SIZEOF_VOID_P BUILTIN_TYPES_ONLY)
     
-    if (SIZEOF_VOID_P EQUAL 8)
+    if (SIZEOF_VOID_P EQUAL 8 AND NOT DEFINED ${CMAKE_VS_PLATFORM_NAME})
         message(STATUS "Using Vcpkg triplet 'x64-windows'")
         
         set(VCPKG_TRIPLET x64-windows)
@@ -116,7 +118,7 @@ endmacro()
 macro(_install_or_update_vcpkg)
     if(NOT EXISTS ${VCPKG_ROOT})
         message(STATUS "Cloning vcpkg in ${VCPKG_ROOT}")
-        execute_process(COMMAND git clone https://github.com/Microsoft/vcpkg.git ${VCPKG_ROOT})
+        execute_process(COMMAND git clone https://github.com/Microsoft/vcpkg.git ${VCPKG_ROOT} --depth 1)
 
         # If a reproducible build is desired (and potentially old libraries are # ok), uncomment the
         # following line and pin the vcpkg repository to a specific githash.


### PR DESCRIPTION
Currently on any 64bit system a triplet of `x64-windows` is forced. This is because the existing check only checks for `sizeof(void*) == 8` and not if a the target platform is set. This adds a second check for `CMAKE_VS_PLATFORM_NAME` being defined which is done on the command line.
This fixes targeting `arm64` which is also 64 bit.